### PR TITLE
Fix issue #8  METABASE_DASHBOARD_PATH env var not used and makke port variable because defaul 8080 cause problem with webpack-dev 

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,11 @@ Start the server by running:
 node index.js
 ```
 
-The app runs by default on port 8080.
+The app runs by default on port 8080. If you want to run it on a different port, set the `PORT` environment variable:
+```sh
+export PORT=8081
+```
+
 
 Visit [http://localhost:8080/analytics](localhost:8080/analytics) and sign in with the following credentials:
 

--- a/index.js
+++ b/index.js
@@ -194,7 +194,8 @@ app.get("/sso/metabase", restrict, (req, res) => {
     res.redirect(ssoUrl);
 });
 
-const PORT = 8080;
+const PORT =
+    process.env.PORT || 8080;
 if (!module.parent) {
     app.listen(PORT);
     console.log(`Express started serving on port ${PORT}`);

--- a/index.js
+++ b/index.js
@@ -5,7 +5,8 @@ const METABASE_SITE_URL =
 const METABASE_JWT_SHARED_SECRET =
     process.env.METABASE_JWT_SHARED_SECRET ||
     "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
-
+const METABASE_DASHBOARD_PATH =
+    process.env.METABASE_DASHBOARD_PATH || "/dashboard/1";
 const mods = "logo=false";
 
 /**
@@ -130,8 +131,6 @@ app.get("/", function (req, res) {
 });
 
 app.get("/analytics", restrict, function (req, res) {
-    // replace ID "1" with the ID number in the path of your dashboard in Metabase.
-    const METABASE_DASHBOARD_PATH = "/dashboard/1";
     var iframeUrl = `/sso/metabase?return_to=${METABASE_DASHBOARD_PATH}`;
     res.send(
         `<iframe src="${iframeUrl}" frameborder="0" width="1280" height="1000" allowtransparency></iframe>`


### PR DESCRIPTION
 METABASE_DASHBOARD_PATH env var was not used in Javascript code caused DASHBOARD alsway staticly embeds dashboard/1 without perhaps not beeing available.
Also include setting and usage PORT env - Valiable leaving default 8080 intact, which in some dev-environment might intervene with other used ports  